### PR TITLE
return true on offline saving

### DIFF
--- a/Pod/Classes/NSManagedObject+CRUD.m
+++ b/Pod/Classes/NSManagedObject+CRUD.m
@@ -428,7 +428,7 @@
     if (!httpResponse && crudType != CUSTOM && object) {
         // Cache the response if offline
         [object cacheOffline:crudType];
-        return false;
+        return TRUE;
     } else if ([httpResponse statusCode]==404 && crudType == DELETE){
         // if we attempt to delete something, but we get a 404 from the server, then it might've already been deleted√
         return TRUE;


### PR DESCRIPTION
I think we should return true in the offline saving validation. 

Reason being: once you hand the data off to ROBot, so long as it passes all the "validations", be it local or remote, and it saves successfully, then you should be able to go on using the app like it successfully saved.

I don't think the user of ROBot needs to know that there wasn't internet and that the API call didn't successfully go through. However, the one thing we should be careful of is not depending on IDs — because you won't get one back in the API call.

On that note, remind me to talk to you about UUIDs cause I think that'll solve a good number of issues for us. 

So... thoughts?
